### PR TITLE
BUGFIX: environment values with a '=' sign cause a ValueError

### DIFF
--- a/deployfish/aws/ecs.py
+++ b/deployfish/aws/ecs.py
@@ -378,7 +378,7 @@ class ContainerDefinition(VolumeMixin):
                 self.environment = yml['environment']
             else:
                 for env in yml['environment']:
-                    key, value = env.split('=')
+                    key, value = env.split('=')[0], '='.join(env.split('=')[1:])
                     self.environment[key] = value
         if 'links' in yml:
             self.links = yml['links']


### PR DESCRIPTION
An environment line like:

```
CATALOGER_LDAP_BASE_DN="ou=people,ou=imss,o=caltech,c=us"
```

Produces a ValueError:

```
Traceback (most recent call last):
  File "/Users/smeinel/.pyenv/versions/docker-ve/bin/deploy", line 11, in <module>
    sys.exit(main())
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/deployfish/dplycli.py", line 611, in main
    cli(obj={})
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/deployfish/dplycli.py", line 162, in create
    service = Service(yml=Config(filename=ctx.obj['CONFIG_FILE'], env_file=ctx.obj['ENV_FILE']).get_service(service_name))
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/deployfish/aws/ecs.py", line 723, in __init__
    self.from_yaml(yml)
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/deployfish/aws/ecs.py", line 1015, in from_yaml
    self.desired_task_definition = TaskDefinition(yml=yml)
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/deployfish/aws/ecs.py", line 437, in __init__
    self.from_yaml(yml)
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/deployfish/aws/ecs.py", line 588, in from_yaml
    self.containers = [ContainerDefinition(yml=c_yml) for c_yml in yml['containers']]
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/deployfish/aws/ecs.py", line 97, in __init__
    self.from_yaml(yml)
  File "/Users/smeinel/.pyenv/versions/2.7.13/envs/docker-ve/lib/python2.7/site-packages/deployfish/aws/ecs.py", line 381, in from_yaml
    key, value = env.split('=')
ValueError: too many values to unpack
```