### PR TITLE
Support configuring scheduling strategy when creating service

### DIFF
--- a/deployfish/aws/test/test_Service.py
+++ b/deployfish/aws/test/test_Service.py
@@ -33,6 +33,8 @@ class TestService_load_yaml_deploymenConfiguration_defaults(unittest.TestCase):
         self.assertEqual(self.service.placementConstraints, [])
         self.assertEqual(self.service.placementStrategy, [])
 
+    def test_scheduling_strategy(self):
+        self.assertEqual(self.service.schedulingStrategy, 'REPLICA')
 
 class TestService_load_yaml_deploymenConfiguration_defaults_from_aws(unittest.TestCase):
 

--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -128,10 +128,20 @@ environment
       - name: foobar-prod
         environment: prod
 
+scheduling_strategy
+-------------------
+
+(String, Optional) When we create the ECS service, configure the service to run in REPLICA or DAEMON. Default to REPLICA. ::
+
+    services:
+      - name: foobar-prod
+        clsuter: foodbar-cluster
+        scheduling_strategy: DAEMON
+
 count
 -----
 
-(Integer, Required) When we create the ECS service, configure the service to run this many tasks. ::
+(Integer, Required for REPLICA) When we create the ECS service, configure the service to run this many tasks. ::
 
     services:
       - name: foobar-prod
@@ -146,7 +156,7 @@ maximum_percent
 
 (Integer, Optional) This is the upper limit on the number of tasks
 that are allowed in the RUNNING or PENDING state during a deployment, as a percentage of the ``count``.
-This must be configured along with ``minimum_healthy_percent``. If not provided will default to 200. ::
+This must be configured along with ``minimum_healthy_percent``. If not provided will default to 200. If schdeuling strategy is set to DAMEON, it will be fixd at 100 ::
 
     services:
       - name: foobar-prod


### PR DESCRIPTION
Support to create service in DAMEON. Below is the output of running `deploy create`.

```shell
$ deploy -f test/deployfish.yml create test-service
Using 'test/deployfish.yml' as our deployfish config file

Creating service with these attributes:
  Service info:
    service_name        : test-service
    cluster_name        : test-cluster
    count               : automatically
    Task Definition:
      family                   : test-service
      network_mode             : bridge
      task_role_arn            : arn:aws:iam::0123456789:role/testRole
      containers:
        test-container:
          image                : 0123456789.dkr.ecr.ap-northeast-1.amazonaws.com/test-image:latest
          cpu                  : 2
          memoryReservation    : None

  Waiting until the service is stable ...
Deployment Desired Pending Running
PRIMARY 1 0 1

Service:
(service test-service) has started 1 tasks: (task abcd1234-123d-1234-1234-1234abcdefg).
(daemon service test-service) updated desired count to 1.

Deployment successful.

  Done.
```