### PR TITLE
fix: platform_version option is only configurable if launch type is FARGATE.

### DIFF
--- a/deployfish/aws/ecs/Task.py
+++ b/deployfish/aws/ecs/Task.py
@@ -996,6 +996,9 @@ class Task(object):
         self.taskName = yml['name']
         if 'launch_type' in yml:
             self.launchType = yml['launch_type']
+            if self.launchType == 'FARGATE':
+                if 'platform_version' in yml:
+                    self.platform_version = yml['platform_version']
         self.environment = yml.get('environment', 'undefined')
         self.family = yml['family']
         if 'cluster' in yml:
@@ -1014,8 +1017,6 @@ class Task(object):
             self.placementStrategy = yml['placement_strategy']
         if 'count' in yml:
             self.desired_count = yml['count']
-        if 'platform_version' in yml:
-            self.platform_version = yml['platform_version']
         self.desired_task_definition = TaskDefinition(yml=yml)
         deployfish_environment = {
             "DEPLOYFISH_TASK_NAME": yml['name'],

--- a/deployfish/aws/ecs/TaskScheduler.py
+++ b/deployfish/aws/ecs/TaskScheduler.py
@@ -39,7 +39,7 @@ class TaskScheduler(object):
             parms['NetworkConfiguration'] = {
                 'awsvpcConfiguration': conf
             }
-        parms['PlatformVersion'] = self.task.platform_version
+            parms['PlatformVersion'] = self.task.platform_version
         if self.task.group:
             parms['Group'] = self.task.group
         target['EcsParameters'] = parms
@@ -105,4 +105,3 @@ class TaskScheduler(object):
         Delete the AWS Cloudwatch event rule, with any existing targets.
         """
         self._delete_rule()
-


### PR DESCRIPTION
This PR fixed the execution failure about `deploy task schedule xxx-service` if launch type is EC2.

And also fixed for tasks with ecs services.