### PR TITLE
BUGFIX: deploy exec --verbose once again functions correctly.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,4 @@ nose==1.3.7                                   # https://github.com/nose-devs/nos
 
 # Other utils
 # ------------------------------------------------------------------------------
-colorama==0.3.7                               # https://github.com/tartley/colorama
 ipython==7.1.0                                # https://github.com/ipython/ipython


### PR DESCRIPTION
The issue was that the 'quiet' argument on the ssh() methods for the two Providers was being called with quiet=True, which had been accidentally coded to override --verbose.

Now, the quiet flag (ssh -q) is sent by default, but if --verbose is specified, `ssh -vv` is used instead.