### PR TITLE
BUGFIX: Error reporting for "multiple log groups found" no longer crashes.

### DIFF
--- a/deployfish/core/models/cloudwatchlogs.py
+++ b/deployfish/core/models/cloudwatchlogs.py
@@ -150,9 +150,9 @@ class CloudWatchLogGroupManager(Manager):
         )
         if len(response['logGroups']) > 1:
             raise CloudWatchLogGroup.MultipleObjectsReturned(
-                "Got more than one log group when searching for pk={}".format(
+                "Got more than one log group when searching for logGroupNamePrefix='{}': {}".format(
                     pk,
-                    ", ".join([group for group in response['logGroups']])
+                    ", ".join([group['logGroupName'] for group in response['logGroups']])
                 )
             )
         elif len(response['logGroups']) == 0:


### PR DESCRIPTION
It also now correctly lists the names of the log groups that it found, instead of building the list and then dropping it on the floor.