### PR TITLE
New feature to show diff

### DIFF
--- a/deployfish/core/adapters/deployfish/ecs.py
+++ b/deployfish/core/adapters/deployfish/ecs.py
@@ -34,10 +34,9 @@ class VpcConfigurationMixin:
         if not source:
             source = self.data.get('vpc_configuration', None)
         if source:
-            # sort the subnets and security_groups so that we can compare them easily
-            data['subnets'] = sorted(source['subnets'])
+            data['subnets'] = source['subnets']
             if 'security_groups' in source:
-                data['securityGroups'] = sorted(source['security_groups'])
+                data['securityGroups'] = source['security_groups']
             if 'public_ip' in source:
                 data['assignPublicIp'] = source['public_ip']
             else:
@@ -1354,7 +1353,6 @@ class ServiceAdapter(SSHConfigMixin, SecretsMixin, VpcConfigurationMixin, Adapte
 
         :rtype: dict(str, *)
         """
-        data['status'] = '(known after save)'
         data['cluster'] = self.data['cluster']
         data['serviceName'] = self.data['name']
         if 'load_balancer' in self.data:

--- a/deployfish/core/adapters/deployfish/ecs.py
+++ b/deployfish/core/adapters/deployfish/ecs.py
@@ -334,8 +334,6 @@ class TaskDefinitionAdapter(TaskDefinitionFARGATEMixin, Adapter):  # type: ignor
             data['runtimePlatform']['operatingSystemFamily'] = self.data['runtime_platform'].get('operating_system_family', 'LINUX')
         if self.data.get('placementConstraints', None):
             data['placementConstraints'] = self.data['placementConstraints']
-        else:
-            data['placementConstraints'] = []
         self.set(data, 'task_role_arn', dest_key='taskRoleArn', optional=True)
         self.set(data, 'execution_role', dest_key='executionRoleArn', optional=True)
         if not self.partial and (launch_type == 'FARGATE' and not data['executionRoleArn']):
@@ -768,8 +766,6 @@ class ContainerDefinitionAdapter(Adapter):
             )
         if cpu is not None:
             data['cpu'] = cpu
-        else:
-            data['cpu'] = 0
         memory = self.get_memory()
         if memory is not None:
             data['memory'] = memory
@@ -799,12 +795,6 @@ class ContainerDefinitionAdapter(Adapter):
             data['environment'] = self.get_environment()
         if 'volumes' in self.data:
             data['mountPoints'] = self.get_mountPoints()
-        else:
-            data['mountPoints'] = []
-        if 'volumesFrom' not in self.data:
-            data['volumesFrom'] = []
-        if 'systemControls' not in self.data:
-            data['systemControls'] = []
         self.set(data, 'links', optional=True)
         self.set(data, 'dockerLabels', optional=True)
         if 'logging' in self.data:
@@ -865,12 +855,8 @@ class StandaloneTaskAdapter(SecretsMixin, AbstractTaskAdapter):
             data['capacityProviderStrategy'] = self.data['capacity_provider_strategy']
         if 'placement_constraints' in self.data:
             data['placementConstraints'] = self.data['placement_constraints']
-        else:
-            data['placementConstraints'] = []
         if 'placement_strategy' in self.data:
             data['placementStrategy'] = self.data['placement_strategy']
-        else:
-            data['placementStrategy'] = []
         if 'group' in self.data:
             data['Group'] = self.data['group']
         if 'count' in self.data:
@@ -1391,28 +1377,15 @@ class ServiceAdapter(SSHConfigMixin, SecretsMixin, VpcConfigurationMixin, Adapte
             data['networkConfiguration']['awsvpcConfiguration'] = vpc_configuration
         if 'placement_constraints' in self.data:
             data['placementConstraints'] = self.data['placement_constraints']
-        else:
-            data['placementConstraints'] = []
         if 'placement_strategy' in self.data:
             data['placementStrategy'] = self.data['placement_strategy']
-        else:
-            data['placementStrategy'] = []
         if 'healthCheckGracePeriodSeconds' in self.data:
             data['healthCheckGracePeriodSeconds'] = self.data['healthCheckGracePeriodSeconds']
-        else:
-            data['healthCheckGracePeriodSeconds'] = 0
         data['deploymentConfiguration'] = {}
         data['deploymentConfiguration']['maximumPercent'] = int(self.data.get('maximum_percent', 200))
         data['deploymentConfiguration']['minimumHealthyPercent'] = int(
             self.data.get('minimum_healthy_percent', 50)
         )
-        data['deploymentConfiguration']['deploymentCircuitBreaker'] = {}
-        data['deploymentConfiguration']['deploymentCircuitBreaker']['enable'] = self.data.get('enable_circuit_breaker', False)
-        data['deploymentConfiguration']['deploymentCircuitBreaker']['rollback'] = self.data.get('rollback', False)
-        if 'deploymentController' in self.data:
-            data['deploymentController'] = self.data['deploymentController']
-        else:
-            data['deploymentController'] = {'type': 'ECS'}
         data['schedulingStrategy'] = self.data.get('scheduling_strategy', 'REPLICA')
         if data['schedulingStrategy'] == 'DAEMON':
             data['desiredCount'] = 'automatically'
@@ -1426,8 +1399,6 @@ class ServiceAdapter(SSHConfigMixin, SecretsMixin, VpcConfigurationMixin, Adapte
         data['enableECSManagedTags'] = True
         if 'propagateTags' in self.data:
             data['propagateTags'] = self.data['propagateTags']
-        else:
-            data['propagateTags'] = 'NONE'
 
     def __build_Secrets(self) -> List[Secret]:
         """

--- a/deployfish/core/adapters/deployfish/ecs.py
+++ b/deployfish/core/adapters/deployfish/ecs.py
@@ -34,9 +34,10 @@ class VpcConfigurationMixin:
         if not source:
             source = self.data.get('vpc_configuration', None)
         if source:
-            data['subnets'] = source['subnets']
+            # sort the subnets and security_groups so that we can compare them easily
+            data['subnets'] = sorted(source['subnets'])
             if 'security_groups' in source:
-                data['securityGroups'] = source['security_groups']
+                data['securityGroups'] = sorted(source['security_groups'])
             if 'public_ip' in source:
                 data['assignPublicIp'] = source['public_ip']
             else:
@@ -1367,7 +1368,7 @@ class ServiceAdapter(SSHConfigMixin, SecretsMixin, VpcConfigurationMixin, Adapte
 
         :rtype: dict(str, *)
         """
-        data['status'] = '(known after update)'
+        data['status'] = '(known after save)'
         data['cluster'] = self.data['cluster']
         data['serviceName'] = self.data['name']
         if 'load_balancer' in self.data:

--- a/deployfish/core/models/ecs.py
+++ b/deployfish/core/models/ecs.py
@@ -1325,7 +1325,7 @@ class TaskDefinition(TagsMixin, TaskDefinitionFARGATEMixin, SecretsMixin, Model)
         data['version'] = self.version
         data['timestamp'] = self.timestamp
         if 'compatibilities' in data:
-            data['requiresCompatibilities'] = data['compatibilities']
+            # data['requiresCompatibilities'] = data['compatibilities']
             del data['compatibilities']
         if 'volumes' in data:
             for volume in data['volumes']:
@@ -1347,7 +1347,7 @@ class TaskDefinition(TagsMixin, TaskDefinitionFARGATEMixin, SecretsMixin, Model)
             del data['registeredAt']
             del data['registeredBy']
             if 'compatibilities' in data:
-                data['requiresCompatibilities'] = data['compatibilities']
+                # data['requiresCompatibilities'] = data['compatibilities']
                 del data['compatibilities']
             if 'requiresAttributes' in data:
                 del data['requiresAttributes']
@@ -1475,8 +1475,10 @@ class TaskDefinition(TagsMixin, TaskDefinitionFARGATEMixin, SecretsMixin, Model)
             del data['registeredAt']
             del data['registeredBy']
             if 'compatibilities' in data:
-                data['requiresCompatibilities'] = data['compatibilities']
+                # data['requiresCompatibilities'] = data['compatibilities']
                 del data['compatibilities']
+            if 'requiresCompatibilities' in data:
+                data['requiresCompatibilities'] = data['requiresCompatibilities']
             if 'requiresAttributes' in data:
                 del data['requiresAttributes']
         else:
@@ -1554,7 +1556,15 @@ class ContainerDefinition(SecretsMixin, LazyAttributeMixin):
         return data
 
     def render(self) -> Dict[str, Any]:
-        return deepcopy(self.data)
+        data = deepcopy(self.data)
+        if 'environment' in data:
+            if data['environment']:
+                # Alphabetize the environment variables for easier comparison
+                environment = data['environment'].sort(key=lambda item: item['name'])
+                data['environment'] = environment
+            else:
+                data['environment'] = []
+        return data
 
     def copy(self) -> "ContainerDefinition":
         return self.__class__(self.render())
@@ -2236,7 +2246,7 @@ class Service(
         if 'role' in data:
             # We loaded this from deployfish.yml, so we need to define some default
             # values that appear when you describe_services on an active service
-            data['roleArn'] = data['role']
+            # data['roleArn'] = data['role']
             del data['role']
             data['status'] = 'ACTIVE'
             data['propagateTags'] = 'NONE'
@@ -2270,6 +2280,10 @@ class Service(
                 del data['deployments']
             if 'events' in data:
                 del data['events']
+        if 'roleArn' in data:
+            del data['roleArn']
+        if 'platformFamily' in data:
+            del data['platformFamily']
         data['taskDefinition'] = self.task_definition.render_for_diff()
         if self.appscaling:
             data['appscaling'] = self.appscaling.render_for_diff()

--- a/deployfish/core/models/ecs.py
+++ b/deployfish/core/models/ecs.py
@@ -1325,7 +1325,6 @@ class TaskDefinition(TagsMixin, TaskDefinitionFARGATEMixin, SecretsMixin, Model)
         data['version'] = self.version
         data['timestamp'] = self.timestamp
         if 'compatibilities' in data:
-            # data['requiresCompatibilities'] = data['compatibilities']
             del data['compatibilities']
         if 'volumes' in data:
             for volume in data['volumes']:
@@ -1352,7 +1351,6 @@ class TaskDefinition(TagsMixin, TaskDefinitionFARGATEMixin, SecretsMixin, Model)
             del data['registeredAt']
             del data['registeredBy']
             if 'compatibilities' in data:
-                # data['requiresCompatibilities'] = data['compatibilities']
                 del data['compatibilities']
             if 'requiresAttributes' in data:
                 del data['requiresAttributes']
@@ -1483,7 +1481,6 @@ class TaskDefinition(TagsMixin, TaskDefinitionFARGATEMixin, SecretsMixin, Model)
             del data['registeredAt']
             del data['registeredBy']
             if 'compatibilities' in data:
-                # data['requiresCompatibilities'] = data['compatibilities']
                 del data['compatibilities']
             if 'requiresCompatibilities' in data:
                 data['requiresCompatibilities'] = data['requiresCompatibilities']
@@ -2266,7 +2263,7 @@ class Service(
         if 'role' in data:
             # We loaded this from deployfish.yml, so we need to define some default
             # values that appear when you describe_services on an active service
-            # data['roleArn'] = data['role']
+            data['roleArn'] = data['role']
             del data['role']
             data['status'] = 'ACTIVE'
             data['propagateTags'] = 'NONE'

--- a/deployfish/core/models/ecs.py
+++ b/deployfish/core/models/ecs.py
@@ -1371,7 +1371,8 @@ class TaskDefinition(TagsMixin, TaskDefinitionFARGATEMixin, SecretsMixin, Model)
             for d in data['containerDefinitions']:
                 if 'secrets' in d:
                     del d['secrets']
-        self._tags['Timestamp'] = datetime.datetime.utcnow().strftime('%Y/%m/%dT%H:%M:%SZ')
+        if 'Timestamp' not in self._tags:
+            self._tags['Timestamp'] = datetime.datetime.now(datetime.UTC).strftime('%Y/%m/%dT%H:%M:%SZ')
         data['tags'] = self.render_tags()
         if not data['tags']:
             del data['tags']
@@ -2157,6 +2158,11 @@ class Service(
         if 'tags' in data_kwargs:
             instance.tags.update(data_kwargs['tags'])
         instance.helper_tasks = ServiceHelperTask.new(obj, source, service=instance)
+        if 'task_definition' in data_kwargs:
+            # Update instance.task_definition with Timestamp and deployfish command tags
+            instance.task_definition.tags['Timestamp'] = "(known after save)"
+            for task in instance.helper_tasks:
+                instance.task_definition.tags[f'deployfish:command:{task.command}'] = "(known after save)"
         return instance
 
     def __init__(self, data: Dict[str, Any], **kwargs):

--- a/deployfish/core/models/ecs.py
+++ b/deployfish/core/models/ecs.py
@@ -2322,6 +2322,17 @@ class Service(
             data['deploymentConfiguration']['deploymentCircuitBreaker']['rollback'] = False
         if 'deploymentController' not in data:
             data['deploymentController'] = {'type': 'ECS'}
+        # sort the subnets and security_groups so that we can compare them easily
+        if 'networkConfiguration' in data:
+            if 'awsvpcConfiguration' in data['networkConfiguration']:
+                if 'subnets' in data['networkConfiguration']['awsvpcConfiguration']:
+                    data['networkConfiguration']['awsvpcConfiguration']['subnets'] = sorted(
+                        data['networkConfiguration']['awsvpcConfiguration']['subnets']
+                    )
+                if 'security_groups' in data['networkConfiguration']['awsvpcConfiguration']:
+                    data['networkConfiguration']['awsvpcConfiguration']['security_groups'] = sorted(
+                        data['networkConfiguration']['awsvpcConfiguration']['security_groups']
+                    )
         return data
 
     def render_for_create(self) -> Dict[str, Any]:

--- a/deployfish/core/models/mixins.py
+++ b/deployfish/core/models/mixins.py
@@ -87,8 +87,9 @@ class TagsMixin:
 
     def render_tags(self: SupportsTags) -> List[Dict[str, str]]:
         data: List[Dict[str, str]] = []
-        for key, value in list(self.tags.items()):
-            data.append({'key': key, 'value': value})
+        # Loop through the tags in sorted order
+        for key in sorted(self.tags):
+            data.append({'key': key, 'value': self.tags[key]})
         return data
 
 

--- a/deployfish/templates/macros/task-definition.jinja2
+++ b/deployfish/templates/macros/task-definition.jinja2
@@ -196,6 +196,11 @@ task cpu            :     {{ obj.data['cpu'] }}
 {%- if 'memory' in obj.data %}
 task memory         :     {{ obj.data['memory'] }}
 {%- endif %}
+{%- if 'runtimePlatform' in obj.data %}
+{{ subsection('runtime platform') }}
+  cpu architecture  :     {{ obj.data['runtimePlatform']['cpuArchitecture'] }}
+  os family         :     {{ obj.data['runtimePlatform']['operatingSystemFamily'] }}
+{%- endif %}
 {%- if 'volumes' in obj.data and obj.data['volumes'] %}
 
 {% for volume_def in obj.render_for_display()['volumes'] -%}
@@ -208,4 +213,3 @@ task memory         :     {{ obj.data['memory'] }}
 {{- container(container_obj)|indent(width=2) }}
 {%- endfor -%}
 {% endmacro %}
-

--- a/deployfish/templates/macros/utils.jinja2
+++ b/deployfish/templates/macros/utils.jinja2
@@ -22,3 +22,7 @@ General macros for use in any template
 {% for key, value in tag_dict.items() %}    {{ key|color(fg='yellow') }}: {{ value }}
 {% endfor -%}
 {% endmacro %}
+
+{% macro indent(depth) %}
+{{- '  ' * depth -}}
+{% endmacro %}

--- a/deployfish/templates/plan--service.jinja2
+++ b/deployfish/templates/plan--service.jinja2
@@ -49,7 +49,15 @@
                     {{ render_diff(orig, diff[key], prefix + '.' + key, key, mode, debug) }}
                 {%- elif mode == '$update' -%}
                     {#- Original has the key, but we don't want to increment the prefix depth -#}
+                    {%- if key == 'value' and 'key' not in diff -%}
+                        {#- If this is a tag pair, then we want to print the key for indentification -#}
+                        {{ render_diff(orig, orig['key'], prefix, 'key', None, debug) }}
+                    {%- endif -%}
                     {{ render_diff(orig, diff[key], prefix, key, mode, debug) }}
+                    {%- if key == 'key' and 'value' not in diff -%}
+                        {#- If this is a tag pair, then we want to print the value for indentification -#}
+                        {{ render_diff(orig, orig['value'], prefix, 'value', None, debug) }}
+                    {%- endif -%}
                 {%- else -%}
                     {{ render_diff(orig[key], diff[key], prefix + '.' + key, key, mode, debug) }}
                 {%- endif -%}
@@ -97,6 +105,7 @@ UNHANDLED
     {#- Prefixed a symbol if mode is present -#}
     {%- if mode == '$update' -%}
 {%- if debug -%}(4) {{ depth}} {% endif -%}
+{#- Special case for key:value pairs - specifically supporting tags -#}
 {{ indent(depth) }}{{ diff_sym(mode) }} {{ pkey }}: {{ orig[pkey] }} {%- filter color(fg='yellow') %} -> {{ diff }}{% endfilter -%}
     {%- elif mode == '$insert' -%}
 {%- if debug -%}(5) {{ depth}} {% endif -%}
@@ -106,8 +115,17 @@ UNHANDLED
 {{ indent(depth) }}{{ diff_sym(mode) }} {{ pkey }}: {{ orig[diff] }}
         {%- filter color(fg='red') %} -> null{% endfilter -%}
     {%- else -%}
+        {#- This is where a key and value prints out without a mode -#}
+        {%- if pkey == 'value' -%}
+{#- Newline #}
+{# Newline -#}
+        {%- endif -%}
 {%- if debug -%}(7) {{ depth}} {% endif -%}
-{{ indent(depth) }}{{ diff }}
+{{ indent(depth) }}  {{ pkey }}: {{ diff }}
+        {%- if pkey != 'value' -%}
+{#- Newline #}
+{# Newline -#}
+        {%- endif -%}
     {%- endif -%}
 {%- endif -%}
 {%- endmacro -%}

--- a/deployfish/templates/plan--service.jinja2
+++ b/deployfish/templates/plan--service.jinja2
@@ -1,0 +1,121 @@
+{%- from 'macros/utils.jinja2' import indent -%}
+{#- For adding the characters representing the modes -#}
+{%- macro diff_sym(mode) -%}
+    {%- if mode == '$update' -%}
+        {%- filter color(fg='yellow') %}~{% endfilter -%}
+    {%- elif mode == '$insert' -%}
+        {%- filter color(fg='green') %}+{% endfilter -%}
+    {%- elif mode == '$delete' -%}
+        {%- filter color(fg='red') %}-{% endfilter -%}
+    {%- else -%}
+        ?
+    {%- endif -%}
+{%- endmacro -%}
+{#- Recursive macro to loop through the changes -#}
+{%- macro render_diff(orig, diff, prefix="", pkey="", mode=None, debug=False) -%}
+{%- set depth = prefix.split('.')|length - 2 -%}
+{#- Check if diff is a dictionary or a list -#}
+{%- if diff is mapping -%}
+    {#- Handles the case where diff is a dictionary -#}
+    {%- for key, value in diff.items() -%}
+        {%- if key in ['$update', '$insert', '$delete'] -%}
+            {%- set new_mode = key -%}
+        {%- else -%}
+            {%- set new_mode = None %}
+
+        {%- endif -%}
+        {#- Recursive based on mode and value -#}
+        {%- if new_mode -%}
+            {{ render_diff(orig, diff[key], prefix, pkey, new_mode, debug) }}
+        {%- elif key != '0' and key|int == 0 -%}
+            {#- Key is a string -#}
+            {%- if value is mapping or (value is sequence and value is not string ) -%}
+                {#- Print key because the value will nest further -#}
+{%- if debug -%}(1) {{ depth}} {% endif -%}
+{{ indent(depth) }}{{ diff_sym(mode) }} {{ key }}: {
+{{ render_diff(orig[key], diff[key], prefix + '.' + key, key, mode, debug) }}
+{% if debug -%}(1) {{ depth}} {% endif -%}
+{{ indent(depth) }}}{#- Remove spacing -#}
+            {%- elif value is sequence and value is not string -%}
+{%- if debug -%}(2) {{ depth}} {% endif -%}
+{{ indent(depth) }}{{ diff_sym(mode) }} {{ key }}: [
+{{ render_diff(orig[key], diff[key], prefix + '.' + key, key, mode, debug) }}
+{% if debug -%}(2) {{ depth}} {% endif -%}
+{{ indent(depth) }}]{#- Remove spacing -#}
+            {%- else -%}
+                {#- Value is a string or a number -#}
+                {%- if mode == '$insert' -%}
+                    {#- Original does not have the key, do not add it -#}
+                    {{ render_diff(orig, diff[key], prefix + '.' + key, key, mode, debug) }}
+                {%- elif mode == '$update' -%}
+                    {#- Original has the key, but we don't want to increment the prefix depth -#}
+                    {{ render_diff(orig, diff[key], prefix, key, mode, debug) }}
+                {%- else -%}
+                    {{ render_diff(orig[key], diff[key], prefix + '.' + key, key, mode, debug) }}
+                {%- endif -%}
+            {%- endif -%}
+        {%- else -%}
+            {#- key is an index like '0', '1', '2', etc. -#}
+{%- if debug -%}(3) {{ depth}} {% endif -%}
+{{ indent(depth) }}{{ diff_sym(mode) }} {{ key }}: {
+{{ render_diff(orig[key|int], diff[key], prefix + '.'+ key, pkey, mode, debug) }}
+{% if debug -%}(3) {{ depth}} {% endif -%}
+{{ indent(depth) }}}{#- Remove spacing -#}
+        {%- endif -%}
+        {%- if not loop.last -%}
+{#- Newline #}
+{# Newline -#}
+        {%- endif -%}
+    {%- endfor -%}
+{%- elif diff is sequence and diff is not string -%}
+    {#- Handle the case where diff is a list with an index and string vs a list of values -#}
+    {%- if mode == '$insert' -%}
+        {#- Should be a list of [index, value] to insert-#}
+        {%- for item in diff -%}
+            {#- jsondiff lists $insert before $delete, but to properly reflect the change, $delete happens first -#}
+            {#- increment the index to hopefully deal with the missmatch -#}
+            {{ render_diff(orig[item[0]], item[1], prefix, item[0] + 1, mode, debug) }}
+            {%- if not loop.last -%}
+{#- Newline #}
+{# Newline -#}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- elif mode == '$delete' -%}
+        {#- Should be a list of indexes to delete -#}
+        {%- for item in diff -%}
+            {{ render_diff(orig, item, prefix, item, mode, debug) }}
+            {%- if not loop.last -%}
+{#- Newline #}
+{# Newline -#}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+UNHANDLED
+    {%- endif -%}
+{%- else -%}
+    {#- Handles the case where diff is neither a dictionary nor a list, or it's a string -#}
+    {#- Prefixed a symbol if mode is present -#}
+    {%- if mode == '$update' -%}
+{%- if debug -%}(4) {{ depth}} {% endif -%}
+{{ indent(depth) }}{{ diff_sym(mode) }} {{ pkey }}: {{ orig[pkey] }} {%- filter color(fg='yellow') %} -> {{ diff }}{% endfilter -%}
+    {%- elif mode == '$insert' -%}
+{%- if debug -%}(5) {{ depth}} {% endif -%}
+{{ indent(depth) }}{{ diff_sym(mode) }} {{ pkey }}: {% filter color(fg='green') %}{{ diff }}{% endfilter -%}
+    {%- elif mode == '$delete' -%}
+{%- if debug -%}(6) {{ depth}} {% endif -%}
+{{ indent(depth) }}{{ diff_sym(mode) }} {{ pkey }}: {{ orig[diff] }}
+        {%- filter color(fg='red') %} -> null{% endfilter -%}
+    {%- else -%}
+{%- if debug -%}(7) {{ depth}} {% endif -%}
+{{ indent(depth) }}{{ diff }}
+    {%- endif -%}
+{%- endif -%}
+{%- endmacro -%}
+{# Now call the macro to loop through the changes #}
+{% filter color(fg='green') %}Service: {% endfilter %}{{ obj.pk|color(fg='cyan', bold=True) }}
+{% if debug %}{% filter color(fg='yellow') %}Debugging...{% endfilter %}{% endif%}
+{{ render_diff(aws_json, changes, 'services.' + obj.pk, "", None, debug) }}
+
+Run update command to apply changes:
+
+  deploy update {{ obj.name }}


### PR DESCRIPTION
This adds `deploy service plan` which will display any possible changes when running `deploy service update`. It is currently noted as experimental in the description. This takes advantage of the existing `render_for_diff` methods in the Model classes.

To make things consistent, certain defaults were set in the render methods. Configurations with stored lists of values like `subnets` and `security_groups` were sorted to avoid unnecessary updates changes. I had removed lines where `requiresCapabilities` were being set as `capabilities`.

This update also adds support for `runtimePlatform` in order to spin up the service in AMD64 or ARM64.