### PR TITLE
Move catch for botocore.exceptions.UnauthorizedSSOTokenError to main.

### DIFF
--- a/deployfish/config/processors/terraform.py
+++ b/deployfish/config/processors/terraform.py
@@ -2,8 +2,6 @@ import json
 import os
 import os.path
 import re
-import sys
-import click
 from typing import Dict, List, Any, Union, TYPE_CHECKING, cast
 
 import boto3
@@ -78,9 +76,6 @@ class TerraformS3State(AbstractTerraformState):
         key = s3.Object(bucket, filename)
         try:
             state_file = key.get()["Body"].read().decode('utf-8')
-        except botocore.exceptions.UnauthorizedSSOTokenError as ex:
-            click.secho(str(ex), fg='red')
-            sys.exit(1)
         except botocore.exceptions.ClientError as ex:
             if ex.response['Error']['Code'] == 'NoSuchKey':
                 raise NoSuchTerraformStateFile("Could not find Terraform state file {}".format(state_file_url))

--- a/deployfish/main.py
+++ b/deployfish/main.py
@@ -1,8 +1,10 @@
 import os
 from typing import Any, Optional, Dict
 
+from botocore.exceptions import UnauthorizedSSOTokenError
 from cement import App, init_defaults
 from cement.core.exc import CaughtSignal
+import click
 
 import deployfish.core.adapters  # noqa:F401,F403  # pylint:disable=unused-import
 
@@ -241,6 +243,10 @@ def main():
             if app.debug is True:
                 import traceback
                 traceback.print_exc()
+
+        except UnauthorizedSSOTokenError as ex:
+            click.secho(str(ex), fg='red')
+            app.exit_code = 1
 
         except DeployfishAppError as e:
             print('DeployfishAppError > %s' % e.args[0])


### PR DESCRIPTION
The error was being caught in TerraformS3State, but it wasn't being caught when AWSSessionBuilder gets a session with a profile that has allowed_account_ids or forbidden_account_ids. Letting the error bubble up to main will allow us to catch all of them.