### PR TITLE
BUGFIX: modified some render_for_diff attributes and handle a list up…

### DIFF
--- a/deployfish/core/models/appscaling.py
+++ b/deployfish/core/models/appscaling.py
@@ -189,6 +189,8 @@ class ScalableTarget(Model):
                 'ScheduledScalingSuspended': False
             }
         data['scaling_policies'] = [p.render_for_diff() for p in sorted(self.policies, key=lambda x: x.pk)]
+        if 'ScalableTargetARN' in data:
+            del data['ScalableTargetARN']
         return data
 
     def render_for_create(self) -> Dict[str, Any]:

--- a/deployfish/core/models/ecs.py
+++ b/deployfish/core/models/ecs.py
@@ -1357,9 +1357,8 @@ class TaskDefinition(TagsMixin, TaskDefinitionFARGATEMixin, SecretsMixin, Model)
         else:
             if 'placementConstraints' not in data:
                 data['placementConstraints'] = []
-            if 'requiresCompatibilities' not in data:
-                data['requiresCompatibilities'] = ['EC2']
-
+        if 'requiresCompatibilities' not in data:
+            data['requiresCompatibilities'] = ['EC2']
         return data
 
     def render(self):

--- a/deployfish/templates/plan--service.jinja2
+++ b/deployfish/templates/plan--service.jinja2
@@ -98,7 +98,21 @@
             {%- endif -%}
         {%- endfor -%}
     {%- else -%}
-UNHANDLED
+        {#- Should be a list of values to update -#}
+        {%- if orig|length == 0 -%}
+            {%- set new_mode = '$insert' -%}
+            {#- orig is a list with no content - this is really an insert -#}
+            {%- for item in diff -%}
+{%- if debug -%}(8) {{ depth}} {% endif -%}
+{{ indent(depth) }}{{ diff_sym(new_mode) }} {{ loop.index }} : {
+{{ render_diff(orig, item, prefix, key, new_mode, debug) }}
+{% if debug -%}(8) {{ depth}} {% endif -%}
+{{ indent(depth) }}}{#- Remove spacing -#}
+            {%- endfor -%}
+        {%- else -%}
+            {#- orig is a list with content - jsondiff should provide a different format -#}
+            UNHANDLED
+        {%- endif -%}
     {%- endif -%}
 {%- else -%}
     {#- Handles the case where diff is neither a dictionary nor a list, or it's a string -#}


### PR DESCRIPTION
…date that is really an insert plan template.

Deleted ScalableTargetARN from ScalableTarget.render_for_diff since I don't think we have control of that value, and it doesn't provide much information.

Task definition template was missing requiresCapabilities for an older service due to taskDefinitionArn not in the render data. I moved it out of the conditional.

The old service also revealed a unhandled section in service plan template macro: a list update that is really a list insert in disguise. It seems that service AWS obj had empty list of tags but the deplofish object contained a tag. (This might relate our terraform files because our more recent services have that tag saved.) Jsondiff registered this difference as an update to the list and not an insert. So I looped through the update list of dicts and set the mode to insert to properly display the new list items.