### PR TITLE
A few simple fixes

### DIFF
--- a/deployfish/controllers/service.py
+++ b/deployfish/controllers/service.py
@@ -249,7 +249,7 @@ class ECSService(CrudBase):
         obj.scale(count)
         self.scale_services_waiter(obj)  # type: ignore
         self.app.print(
-            click.style('\n\nScaled {}("{}") to {} tasks.'.format(self.model.__name__, obj.pk, count), fg='green')
+            click.secho('\n\nScaled {}("{}") to {} tasks.'.format(self.model.__name__, obj.pk, count), fg='green')
         )
         for _ in self.app.hook.run('post_service_scale', self.app, obj, count):
             pass
@@ -275,7 +275,7 @@ class ECSService(CrudBase):
         obj = loader.get_object_from_aws(self.app.pargs.pk)
         obj = cast(Service, obj)
         obj.restart(hard=self.app.pargs.hard, waiter_hooks=[ECSDeploymentStatusWaiterHook(obj)])
-        return click.style('\n\nRestarted tasks for {}("{}").'.format(self.model.__name__, obj.pk), fg='green')
+        return click.secho('\n\nRestarted tasks for {}("{}").'.format(self.model.__name__, obj.pk), fg='green')
 
     @ex(
         help='List the running tasks for an ECS Service in AWS.',
@@ -339,7 +339,6 @@ class ECSServiceStandaloneTasks(Controller):
 
     model: Type[Model] = Service
     loader: Type[ObjectLoader] = ServiceLoader
-
 
     @ex(
         help='List StandaloneTasks related to a Service from configuration in deployfish.yml',
@@ -428,7 +427,6 @@ class ECSServiceStandaloneTasks(Controller):
             click.secho('\nDone.', fg='yellow')
         else:
             self.app.print('No related tasks.')
-
 
 
 class ECSServiceSecrets(ObjectSecretsController):

--- a/deployfish/core/models/ecs.py
+++ b/deployfish/core/models/ecs.py
@@ -2780,6 +2780,12 @@ class Service(
         """
         if not waiter_hooks:
             waiter_hooks = []
+        if len(self.running_tasks) == 0:
+            # If there aren't any running tasks to restart, we have nothing to do but inform the user of said fact.
+            raise self.NoRunningTasks(
+                f'Service "{self.data["serviceName"]}" has no running tasks.'
+            )
+
         waiter = self.objects.get_waiter('services_stable')
         for task in self.running_tasks:
             task.delete()


### PR DESCRIPTION
I originally wrote this to make it so the `service restart` command doesn't just silently fail if there are no running tasks. But in the process of fixing that, I realized that the reason it was being *entirely* silent was that the printout that said `Restarted tasks for Service("<service-name>").` at the end of `service restart` was not being printed. This was due to the function `click.style()` being used where I'm fairly sure `click.secho()` was intended.

So I corrected two places where that substitution was happening, and also added a code path to properly inform the user if there were no tasks to restart.