### PR TITLE
Fixed that annoying syntax warning about an invalid escape sequence.

### DIFF
--- a/deployfish/core/ssh.py
+++ b/deployfish/core/ssh.py
@@ -161,7 +161,7 @@ class AbstractSSHProvider:
 
 
 class SSMSSHProvider(AbstractSSHProvider):
-    """
+    r"""
     Implement our SSH commands via AWS Systems Manager SSH connections directly
     to :py:attr:`instance`.
 


### PR DESCRIPTION
Python is going to turn this warning into a syntax error soon, which is why it's now a warning instead of just being ignored.

Of the two available solutions (escape the \ with another \, or make the docstring a raw string, I went with raw string so that anyone copying the example code directly out of the .py file (rather than the docs) won't get an invalid SSH ProxyCommand line.