### PR TITLE
Pinned setuptools to < 80 so it'll stop complaining about pkg_resources being deprecated

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     slackfin >= 0.2.2
     gitpython >= 3.1.43
     giturlparse >= 0.12.0
-    setuptools >= 74.1.2
+    setuptools < 80
     simplesqs >= 0.4.0
     toml >= 0.10.2
 


### PR DESCRIPTION
Without this change you'll get spammed with this warning every single time you run `deploy`:

deployfish/deployfish/ext/ext_df_plugin.py:9: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81

Pinning to < 81 didn't help, because the version that's throwing this warning is 80.9. So I pinned to < 80.